### PR TITLE
feat: プレイヤー生存フラグの作成

### DIFF
--- a/MultiverseShooting/Assets/Prefabs/HealthPoint.prefab
+++ b/MultiverseShooting/Assets/Prefabs/HealthPoint.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3200664332975999481
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1116180805466444149}
+  - component: {fileID: 3074516963579209614}
+  m_Layer: 0
+  m_Name: HealthPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1116180805466444149
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200664332975999481}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.517323, y: 0.4420258, z: -0.057364482}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3074516963579209614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3200664332975999481}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad9c13743f4d1984cbe231181faef0ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/MultiverseShooting/Assets/Prefabs/HealthPoint.prefab.meta
+++ b/MultiverseShooting/Assets/Prefabs/HealthPoint.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 53d8c867e74b4654693c45ec1e3b05e0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Prefabs/hitCircle.prefab
+++ b/MultiverseShooting/Assets/Prefabs/hitCircle.prefab
@@ -1,0 +1,135 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4018481455575524278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4382665115734120520}
+  - component: {fileID: 4836833008077481336}
+  - component: {fileID: 3098037303140432844}
+  - component: {fileID: 7400594446392304827}
+  m_Layer: 0
+  m_Name: hitCircle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4382665115734120520
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4018481455575524278}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4836833008077481336
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4018481455575524278}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 99
+  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
+  m_Color: {r: 1, g: 0, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &3098037303140432844
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4018481455575524278}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.5
+--- !u!114 &7400594446392304827
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4018481455575524278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f8ced83165fa74946b9aa52bf427e771, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/MultiverseShooting/Assets/Prefabs/hitCircle.prefab.meta
+++ b/MultiverseShooting/Assets/Prefabs/hitCircle.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b894363cfa0c1c4abda51055a50fd3e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Scenes/GameScene.unity
+++ b/MultiverseShooting/Assets/Scenes/GameScene.unity
@@ -122,90 +122,73 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &597691504
-GameObject:
+--- !u!1001 &102465952
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 597691506}
-  - component: {fileID: 597691505}
-  m_Layer: 0
-  m_Name: hitCircle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!212 &597691505
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 597691504}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 99
-  m_Sprite: {fileID: -2413806693520163455, guid: a86470a33a6bf42c4b3595704624658b, type: 3}
-  m_Color: {r: 1, g: 0, b: 0, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!4 &597691506
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 597691504}
   serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 1285941889}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1285941889}
+    m_Modifications:
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -1.517323
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.4420258
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.057364482
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3200664332975999481, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+      propertyPath: m_Name
+      value: HealthPoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+--- !u!4 &102465953 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1116180805466444149, guid: 53d8c867e74b4654693c45ec1e3b05e0, type: 3}
+  m_PrefabInstance: {fileID: 102465952}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &597691506 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+  m_PrefabInstance: {fileID: 7660851150422597582}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1285941887
 GameObject:
   m_ObjectHideFlags: 0
@@ -292,6 +275,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 597691506}
+  - {fileID: 102465953}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!50 &1285941890
@@ -483,6 +467,63 @@ MonoBehaviour:
     m_MipBias: 0
     m_VarianceClampScale: 0.9
     m_ContrastAdaptiveSharpening: 0
+--- !u!1001 &7660851150422597582
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1285941889}
+    m_Modifications:
+    - target: {fileID: 4018481455575524278, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_Name
+      value: hitCircle
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4382665115734120520, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8b894363cfa0c1c4abda51055a50fd3e, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/MultiverseShooting/Assets/Scripts/HitCircleScript.meta
+++ b/MultiverseShooting/Assets/Scripts/HitCircleScript.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 46b8ba113351d6642b57d37aa52b9634
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Scripts/HitCircleScript/HitCircleController.cs
+++ b/MultiverseShooting/Assets/Scripts/HitCircleScript/HitCircleController.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HitCircleController : MonoBehaviour
+{
+    private bool isHit = false;
+    private int damage = 0;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void FixedUpdate()
+    {
+        isHit = false;
+    }
+
+    private void OnCollisionEnter2D(Collision2D collision)
+    {
+        if (collision.gameObject.CompareTag("ATK"))
+        {
+            isHit = true;
+            // オブジェクトからダメージ値を持ってくる
+        }
+    }
+
+    public bool getIsHit()
+    {
+        return isHit;
+    }
+
+    public int getDamage()
+    {
+        return damage;
+    }
+}

--- a/MultiverseShooting/Assets/Scripts/HitCircleScript/HitCircleController.cs.meta
+++ b/MultiverseShooting/Assets/Scripts/HitCircleScript/HitCircleController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f8ced83165fa74946b9aa52bf427e771
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Scripts/LifeScript.meta
+++ b/MultiverseShooting/Assets/Scripts/LifeScript.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea46182c43b7184489e17eeb6a5d096a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Scripts/LifeScript/LifeController.cs
+++ b/MultiverseShooting/Assets/Scripts/LifeScript/LifeController.cs
@@ -1,0 +1,36 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class LifeController : MonoBehaviour
+{
+    public readonly int defaultValue = 10;
+    
+    private bool isDead = false;
+    private int value;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        value = defaultValue;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        isDead = value <= 0;
+    }
+
+    public void Damage(int val)
+    {
+        if (value > 0)
+        {
+            value -= val;
+        }
+    }
+
+    public bool getIsDead()
+    {
+        return isDead;
+    }
+}

--- a/MultiverseShooting/Assets/Scripts/LifeScript/LifeController.cs.meta
+++ b/MultiverseShooting/Assets/Scripts/LifeScript/LifeController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad9c13743f4d1984cbe231181faef0ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/Assets/Scripts/PlayerScripts/PlayerDamage.cs
+++ b/MultiverseShooting/Assets/Scripts/PlayerScripts/PlayerDamage.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerDamage : MonoBehaviour
+{
+    public GameObject HP;
+    public GameObject hitCircle;
+
+    private LifeController lc;
+    private HitCircleController hc;
+    // Start is called before the first frame update
+    void Start()
+    {
+        lc = HP.GetComponent<LifeController>();
+        hc = hitCircle.GetComponent<HitCircleController>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        if (lc.getIsDead())
+        {
+            GameOver();
+        }
+
+        if (hc.getIsHit())
+        {
+            lc.Damage(hc.getDamage());
+        }
+    }
+
+    void GameOver()
+    {
+        Debug.Log("Game Over");
+    }
+}

--- a/MultiverseShooting/Assets/Scripts/PlayerScripts/PlayerDamage.cs.meta
+++ b/MultiverseShooting/Assets/Scripts/PlayerScripts/PlayerDamage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 998e3b97fb7bbc14883ca19b2a9d5c5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MultiverseShooting/UserSettings/Layouts/default-2022.dwlt
+++ b/MultiverseShooting/UserSettings/Layouts/default-2022.dwlt
@@ -19,7 +19,7 @@ MonoBehaviour:
     width: 1904
     height: 1093
   m_ShowMode: 4
-  m_Title: Game
+  m_Title: Project
   m_RootView: {fileID: 2}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -119,7 +119,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 37
+  controlID: 85
   draggingID: 0
 --- !u!114 &6
 MonoBehaviour:
@@ -192,8 +192,8 @@ MonoBehaviour:
     y: 0
     width: 329
     height: 690
-  m_MinSize: {x: 201, y: 221}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 14}
   m_Panes:
   - {fileID: 14}
@@ -218,8 +218,8 @@ MonoBehaviour:
     y: 0
     width: 1126
     height: 690
-  m_MinSize: {x: 202, y: 221}
-  m_MaxSize: {x: 4002, y: 4021}
+  m_MinSize: {x: 200, y: 200}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 16}
   m_Panes:
   - {fileID: 15}
@@ -237,7 +237,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
+  m_Name: ProjectBrowser
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -246,14 +246,14 @@ MonoBehaviour:
     y: 690
     width: 1455
     height: 353
-  m_MinSize: {x: 100, y: 100}
-  m_MaxSize: {x: 4000, y: 4000}
-  m_ActualView: {fileID: 17}
+  m_MinSize: {x: 231, y: 271}
+  m_MaxSize: {x: 10001, y: 10021}
+  m_ActualView: {fileID: 13}
   m_Panes:
   - {fileID: 13}
   - {fileID: 17}
-  m_Selected: 1
-  m_LastSelected: 0
+  m_Selected: 0
+  m_LastSelected: 1
 --- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -273,8 +273,8 @@ MonoBehaviour:
     y: 0
     width: 449
     height: 1043
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 18}
   m_Panes:
   - {fileID: 18}
@@ -395,7 +395,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Prefabs
+    - Assets/Scripts/PlayerScripts
     m_Globs: []
     m_OriginalText: 
     m_ImportLogFlags: 0
@@ -403,16 +403,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 81
   m_LastFolders:
-  - Assets/Prefabs
+  - Assets/Scripts/PlayerScripts
   m_LastFoldersGridSize: 81
   m_LastProjectPath: C:\Users\nahnn\source\repos\ShootingProject_2_unity\ShootingProject_2_unity\MultiverseShooting
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 0}
-    m_SelectedIDs: 30710000
-    m_LastClickedID: 28976
-    m_ExpandedIDs: 00000000ae6f00003471000000ca9a3bffffff7f
+    m_SelectedIDs: a4710000
+    m_LastClickedID: 29092
+    m_ExpandedIDs: 00000000c46f00005071000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -440,7 +440,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000ae6f0000
+    m_ExpandedIDs: 00000000c46f0000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -533,9 +533,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 626f0000
-      m_LastClickedID: 28514
-      m_ExpandedIDs: 18fbffff
+      m_SelectedIDs: 48720000
+      m_LastClickedID: 0
+      m_ExpandedIDs: 18fbffff666f0000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 


### PR DESCRIPTION
プレイヤーの生存フラグを作成
HPオブジェクト内のisDeadを基に生死を判定
加えてhitCircleオブジェクトにコライダーをアタッチ
コライダーがATKタグのオブジェクトに接触した際にHPの値を減少させる
HP、hitCircleはプレハブ化したため、敵にも応用可能